### PR TITLE
Remove calling 'apt-get update'.

### DIFF
--- a/lib/itamae/plugin/recipe/docker/install.rb
+++ b/lib/itamae/plugin/recipe/docker/install.rb
@@ -37,10 +37,6 @@ when 'debian'
     not_if 'dpkg -l | grep -q linux-image-amd64'
   end
 
-  execute 'apt-get update' do
-    not_if 'which docker'
-  end
-
   execute 'curl -sSL https://get.docker.com/ | sh' do
     not_if 'which docker'
   end


### PR DESCRIPTION
Current get.docker.com script executes 'apt-get update'.
