### PR TITLE
Bugfix: make not supported error shown on console

### DIFF
--- a/lib/itamae/plugin/recipe/docker/install.rb
+++ b/lib/itamae/plugin/recipe/docker/install.rb
@@ -75,7 +75,7 @@ when 'ubuntu'
   end
 
 else
-  require 'itamae/plugin/recipe/version'
+  require_relative './version'
   abort "'#{node[:platform]}' is not supported by v#{Itamae::Plugin::Recipe::Docker::VERSION} of itamae-plugin-recipe-docker."
 end
 


### PR DESCRIPTION
Currently, on non-supported platform, following error message occurs.

```
   bundler: failed to load command:
   itamae (/Users/USERNAME/.rbenv/versions/2.4.3/bin/itamae)
   LoadError: cannot load such file -- itamae/plugin/recipe/version
```

This commit fixes this to show:

```
   'HOSTCODE' is not supported by v0.2.2 of itamae-plugin-recipe-docker.
```